### PR TITLE
Removing unwanted tilde

### DIFF
--- a/logging/handlers.rst
+++ b/logging/handlers.rst
@@ -27,7 +27,7 @@ To use it, declare it as a service:
             Symfony\Bridge\Monolog\Handler\ElasticsearchLogstashHandler: ~
 
             # optionally, configure the handler using the constructor arguments (shown values are default)
-            Symfony\Bridge\Monolog\Handler\ElasticsearchLogstashHandler: ~
+            Symfony\Bridge\Monolog\Handler\ElasticsearchLogstashHandler:
                 arguments:
                     $endpoint: "http://127.0.0.1:9200"
                     $index: "monolog"


### PR DESCRIPTION
This tilde appears too have been inadvertently copied into this code example.
